### PR TITLE
 NOTICK: updated Node to v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ outputs:
   result: # just a string
     description: 'A simple ok'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
Github started to deprecate NodeJS 12 actions and move them to Node16 environment, see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ more details